### PR TITLE
Update types.d.ts

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,4 +1,18 @@
 /**
+ * Declare ReadableStream and WritableStream in case dom.d.ts is not added to the tsconfig
+ * lib causing ReadableStream or WritableStream interface is not defined. 
+ * For developers with dom.d.ts added, the ReadableStream and WritableStream 
+ * interface will be merged correctly.
+ *
+ * This is also required for any clients with streaming interface where ReadableStream
+ * or WritableStream type is also referred. 
+ */
+declare global {
+    export interface ReadableStream {}
+    export interface WritableStream {}
+}
+
+/**
  * BasicPrimitive
  * @desc Type representing [`BasicPrimitive`](https://www.typescriptlang.org/docs/handbook/release-notes/overview.html#smarter-type-alias-preservation) types in TypeScript
  */


### PR DESCRIPTION
Copied patch for usage with out dom from aws-sdk-js-v3, this seams to work.
This is to fix the last of the common js issues, when building postgresql-client


node_modules/ts-gems/lib/types.d.ts:29:11 - error TS2304: Cannot find name 'ReadableStream'.

29     URL | ReadableStream | WritableStream;
             ~~~~~~~~~~~~~~

node_modules/ts-gems/lib/types.d.ts:29:28 - error TS2304: Cannot find name 'WritableStream'.

29     URL | ReadableStream | WritableStream;
                              ~~~~~~~~~~~~~~
