### PR TITLE
fix: Fix compilation error on DTO type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,7 @@ jobs:
       - run: npm install
       - name: Run lint
         run: npm run lint
+      - name: Run compile
+        run: npm run compile
       - name: Run tests
         run: npm run test

--- a/lib/dto.d.ts
+++ b/lib/dto.d.ts
@@ -9,7 +9,7 @@ import { IfNever } from './type-check.js';
  */
 export type DTO<T> = {
   [K in keyof T as IfNever<
-    Exclude<NonNullable<T[K]> | Function>,
+    Exclude<NonNullable<T[K]>, Function>,
     never,
     K
   >]: NonNullable<T[K]> extends (infer U)[] // Deep process arrays

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "target": "ES6",
     "esModuleInterop": true,
     "noImplicitAny": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "skipLibCheck": false,
   },
   "include": ["src", "test"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
The typescript `Exclude` type expects 2 types parameters, it seems like a typo introduced a compilation error

The CI did not catch it as the tsconfig has `"skipLibCheck": true,` (which skips typechecking of `d.ts` files) inherited and is not running the typescript compiling task.

You can see a failed CI job here : https://github.com/gplassard/ts-gems/actions/runs/12677754421 and a successful one at https://github.com/gplassard/ts-gems/actions/runs/12677770572